### PR TITLE
fix(profile-setting): 프로필 이미지 삭제 시 유저 이미지 상태 초기화 및 취소 버튼 링크 변경

### DIFF
--- a/src/pages/profile-setting/index.tsx
+++ b/src/pages/profile-setting/index.tsx
@@ -59,6 +59,10 @@ function ProfileSetting(): React.JSX.Element {
     setInputStackValue('')
   }
 
+  const handleCancle = () => {
+    navigate('/profile')
+  }
+
   // 기술스택 필터링
   const stackFilter = TECH_STACK.filter(
     (stack: string) =>
@@ -225,6 +229,7 @@ function ProfileSetting(): React.JSX.Element {
     window.URL.revokeObjectURL(previewUrl)
     setpriviewUrl('')
     setImage(null)
+    setUserImage('')
   }
 
   return (
@@ -242,11 +247,12 @@ function ProfileSetting(): React.JSX.Element {
           >
             <p className="text-lg font-bold mb-4">프로필 사진</p>
             <section className="flex gap-8 mb-8">
+              {/* 'Ellipse'를 포함하거나,유저 이미지가 없을 때 유저의 이니셜만 나올 수 있게 함 */}
               <Avatar
                 userImage={
                   previewUrl
                     ? previewUrl
-                    : userImage.includes('Ellipse')
+                    : userImage.includes('Ellipse') || !userImage
                     ? undefined
                     : API_BASE_URL + '/' + userImage
                 }
@@ -391,6 +397,7 @@ function ProfileSetting(): React.JSX.Element {
                   width="fullWidth"
                   color="surface"
                   size="md"
+                  onClick={handleCancle}
                 />
                 <BaseButton
                   content={isUploadLoading ? '저장 중..' : '저장하기'}

--- a/src/pages/profile-setting/index.tsx
+++ b/src/pages/profile-setting/index.tsx
@@ -81,6 +81,10 @@ function ProfileSetting(): React.JSX.Element {
     setSelectedStack(selectedStack.filter((item) => item !== stack))
   }
 
+  // 유저 이미지 있을 경우 '프로필 이미지 삭제'버튼 비활성화
+  const userImgDeleteDisabled =
+    (previewUrl && userImage) || !userImage.includes('Ellipse')
+
   // 프로필 정보 불러오기 함수
   const handleProfileLoad = async (): Promise<void> => {
     try {
@@ -276,15 +280,18 @@ function ProfileSetting(): React.JSX.Element {
                     />
                     프로필 이미지 업로드
                   </label>
-                  <BaseButton
-                    content="삭제하기"
-                    fontWeight="normal"
-                    ariaLabel="프로필 업로드 이미지 삭제"
-                    width="flexWidth"
-                    color="surface"
-                    size="sm"
-                    onClick={() => handleUserImageDelete()}
-                  />
+
+                  {userImgDeleteDisabled && (
+                    <BaseButton
+                      content="삭제하기"
+                      fontWeight="normal"
+                      ariaLabel="프로필 업로드 이미지 삭제"
+                      width="flexWidth"
+                      color="surface"
+                      size="sm"
+                      onClick={() => handleUserImageDelete()}
+                    />
+                  )}
                 </div>
                 <p className="text-sm text-text-secondary">
                   이미지는 10mb이하의 jpg,gif,png,jpeg,bmp,tif,heic 확장자로
@@ -313,7 +320,7 @@ function ProfileSetting(): React.JSX.Element {
             </section>
 
             <section className="mb-8">
-              <p className="text-lg font-bold mb-4">introduce</p>
+              <p className="text-lg font-bold mb-4">자기소개</p>
               <textarea
                 className="h-[10rem] bg-background-surface placeholder-text-secondary border border-background-border rounded-lg focus:border-primary focus:outline-none transition-colors
               w-full px-8 lg:p-10 py-2.5 lg:py-3 text-[18px] gap-3"
@@ -352,20 +359,26 @@ function ProfileSetting(): React.JSX.Element {
                   선택된 기술 스택
                 </p>
                 <div className="grid grid-cols-4 gap-4">
-                  {selectedStack.map((stack) => (
-                    <BaseButton
-                      key={stack}
-                      content={stack}
-                      ariaLabel={stack}
-                      onClick={() => stackDelete(stack)}
-                      fontWeight="normal"
-                      width="flexWidth"
-                      color="primary"
-                      size="sm"
-                      icon="/src/assets/icons/close-b-sm.svg"
-                      isLeft={false}
-                    />
-                  ))}
+                  {selectedStack.length > 0 ? (
+                    selectedStack.map((stack) => (
+                      <BaseButton
+                        key={stack}
+                        content={stack}
+                        ariaLabel={stack}
+                        onClick={() => stackDelete(stack)}
+                        fontWeight="normal"
+                        width="flexWidth"
+                        color="primary"
+                        size="sm"
+                        icon="/src/assets/icons/close-b-sm.svg"
+                        isLeft={false}
+                      />
+                    ))
+                  ) : (
+                    <div className="col-span-4 text-center py-8 text-text-secondary">
+                      검색 결과가 없습니다.
+                    </div>
+                  )}
                 </div>
               </section>
               <section className=" mt-4 border-b border-background-border mb-8">

--- a/src/utils/profileStackLoad.ts
+++ b/src/utils/profileStackLoad.ts
@@ -13,9 +13,17 @@ export const LoadIntroData = (introData: string) => {
   if (introData.includes('§$') === true) {
     // '§$'문자열로 자기소개를 배열로 나눔
     const splitIntroData = introData.split('§$')
+
     // '자기소개 텍스트','기술스택'으로 나뉘어짐
     finalIntroduce = splitIntroData[0]
-    finalStack = splitIntroData[1].split(',')
+    const stackString = splitIntroData[1]
+
+    // '기술스택'이 빈 값이 나오지 않게 함
+    if (stackString.trim()) {
+      finalStack = stackString.split(',').filter((stack) => stack.trim() !== '')
+    } else {
+      finalStack = []
+    }
   } else {
     finalIntroduce = introData
     finalStack = []


### PR DESCRIPTION
🎯 작업 내용
이슈 #59 

![프로필수정시연2](https://github.com/user-attachments/assets/dee4e6d5-d979-45d7-a06c-71dea54b2c06)


개발기간
9.24 ~ 9.24

🔄 변경사항

변경페이지
1. src/pages/profile-setting/index.tsx

주요 구현 내용
1.프로필 이미지 삭제 시 기본 이미지(이니셜) 표시 개선
=> 삭제 버튼 클릭시 미리보기 이미지만 삭제되어 기존 서버 이미지가 그대로 유지됨.
=> 삭제 버튼 클릭시 모든 이미지 삭제, 사용자 이름 이니셜만 나올 수 있게 함
=> 이미지가 없을 때는 항상 이니셜만 나오게 함

2.취소 버튼 클릭 시 프로필 페이지로 이동 변경

3.(추가)프로필 이미지가 기본 이미지거나,업로드한 이미지가 없을 때
   '삭제하기' 버튼 비노출 처리
4.(추가)기술스택 빈 값일때 체크(빈 텍스트의 기술 스택 버튼이 안나오게함)


✅ 체크리스트

- [X] 기능 동작 확인
- [X] 타입 에러 없음
- [X] 린트 통과
- [ ] 반응형 확인

Closes #이슈번호
