### PR TITLE
글자수 인코딩시 최대 10byte

### DIFF
--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -26,7 +26,7 @@ interface PostCardProps {
  * @returns
  */
 function PostCard({ isDetail = false, onClick, post }: PostCardProps) {
-  const maxHeight = 100
+  const maxHeight = 300
 
   const navigate = useNavigate()
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -26,6 +26,11 @@
  * - 결과: true 또는 false 반환
  */
 
+// 10byte만 받는 함수
+function getByteLength(str: string): number {
+  return new TextEncoder().encode(str).length
+}
+
 /**
  * 이메일 검증
  */
@@ -45,6 +50,9 @@ export function validateUserName(userName: string): boolean {
   if (userName.trim().length === 0) {
     return false
   }
+  if (getByteLength(userName) > 10) {
+    return false
+  }
 
   return true
 }
@@ -55,7 +63,13 @@ export function validateUserName(userName: string): boolean {
 
 export function validateAccountID(id: string): boolean {
   const idPattern = /^[a-zA-Z0-9._]+$/
-  return idPattern.test(id)
+  if (!idPattern.test(id)) {
+    return false
+  }
+  if (getByteLength(id) > 10) {
+    return false
+  }
+  return true
 }
 
 /**


### PR DESCRIPTION
🎯 작업 내용
이슈 #82 

개발기간
09-26~09-26

🔄 변경사항
utils/validations.ts
userName 및 AccountID 최대 10byte까지만 입력 받도록 수정

✅ 체크리스트

- [x] 10byte만 받는 함수 작성
- [x] userName 및 AccountID에 포함

Closes #82
