### PR TITLE
fix/홈피드의 postcard의 잘못된 api 데이터 가져옴

### DIFF
--- a/src/pages/follower-feed/index.tsx
+++ b/src/pages/follower-feed/index.tsx
@@ -167,7 +167,7 @@ function FollowerFeed(): React.JSX.Element {
                 key={post.id}
                 ref={index === posts.length - 1 ? lastContent : null}
               >
-                <PostCard post={post} onClick={() => {}} />
+                <PostCard post={post} />
               </div>
             ))
           )}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -196,12 +196,12 @@ function Home(): React.JSX.Element {
               </p>
             </div>
           ) : (
-            filteredPosts.map((post, index) => (
+            filteredPosts.map((posts, index) => (
               <div
-                key={post.id}
+                key={posts.id}
                 ref={index === filteredPosts.length - 1 ? lastContent : null}
               >
-                <PostCard post={post} />
+                <PostCard post={posts} />
               </div>
             ))
           )}


### PR DESCRIPTION
🎯 작업 내용
이슈 #89 

개발기간
09-27~09-28

🔄 변경사항
home/index.tsx
follower-feed/index.tsx

팔로워피드 포스트카드 온클릭속성 삭제

홈피드의 api중 post는 게시물 작성시 사용하는 api이고
posts는 피드를 가져올때 사용하는 api
post -> posts로 수정 

✅ 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 린트 통과


Closes #89 
